### PR TITLE
:duck: Add onedrive 2.4.14 to the sntz docker image [STN-172]

### DIFF
--- a/sntz/Dockerfile
+++ b/sntz/Dockerfile
@@ -28,10 +28,19 @@ RUN dpkg --configure -a && \
         libsqlite3-dev \
         pkg-config \
         libnotify-dev \
-        onedrive \
+        gnupg2 \
         python3-dev \
         python3-pip \
+        software-properties-common \
         && \
+    apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 886DDD89 && \
+    add-apt-repository 'deb https://download.opensuse.org/repositories/home:/npreining:/debian-ubuntu-onedrive/xUbuntu_20.04/ ./' && \
+    apt-get update --fix-missing && \
+    wget https://download.opensuse.org/repositories/home:/npreining:/debian-ubuntu-onedrive/xUbuntu_20.04/Release.key && \
+    apt-key add ./Release.key && \
+    apt-get update --fix-missing && \
+    DEBIAN_FRONTEND=noninteractive $APT_INSTALL \
+        onedrive && \
     $GIT_CLONE https://github.com/sstephenson/ruby-build.git \
                 /root/.rbenv/plugins/ruby-build && \
     /root/.rbenv/plugins/ruby-build/install.sh

--- a/sntz/Dockerfile
+++ b/sntz/Dockerfile
@@ -33,17 +33,15 @@ RUN dpkg --configure -a && \
         python3-pip \
         software-properties-common \
         && \
-    apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 886DDD89 && \
-    add-apt-repository 'deb https://download.opensuse.org/repositories/home:/npreining:/debian-ubuntu-onedrive/xUbuntu_20.04/ ./' && \
-    apt-get update --fix-missing && \
-    wget https://download.opensuse.org/repositories/home:/npreining:/debian-ubuntu-onedrive/xUbuntu_20.04/Release.key && \
-    apt-key add ./Release.key && \
-    apt-get update --fix-missing && \
-    DEBIAN_FRONTEND=noninteractive $APT_INSTALL \
-        onedrive && \
     $GIT_CLONE https://github.com/sstephenson/ruby-build.git \
                 /root/.rbenv/plugins/ruby-build && \
     /root/.rbenv/plugins/ruby-build/install.sh
+
+RUN /bin/bash -c "echo 'deb https://download.opensuse.org/repositories/home:/npreining:/debian-ubuntu-onedrive/xUbuntu_20.04/ ./' >> /etc/apt/sources.list" && \
+    /bin/bash -c "wget https://download.opensuse.org/repositories/home:/npreining:/debian-ubuntu-onedrive/xUbuntu_20.04/Release.key" && \
+    /bin/bash -c "apt-key add ./Release.key" && \
+    /bin/bash -c "apt-get update" && \
+    /bin/bash -c "apt install -y onedrive"
 
 ENV PATH /root/.rbenv/bin:$PATH
 

--- a/sntz/Dockerfile
+++ b/sntz/Dockerfile
@@ -1,9 +1,10 @@
-FROM tensorflow/tensorflow:latest
+FROM ubuntu:20.04
 
 LABEL maintainer="Austin Chen <austin.yhc@gmail.com>"
 
 RUN dpkg --configure -a && \
     apt-get update --fix-missing && \
+    apt-get -y upgrade && \
     APT_INSTALL="apt-get install -y --no-install-recommends" && \
     GIT_CLONE="git clone --recurse-submodules --depth 10 -j8" && \
     DEBIAN_FRONTEND=noninteractive $APT_INSTALL \
@@ -21,7 +22,15 @@ RUN dpkg --configure -a && \
         vim \
         rbenv \
         libssl-dev \
+        libffi-dev \
         zlib1g-dev \
+        libcurl4-openssl-dev \
+        libsqlite3-dev \
+        pkg-config \
+        libnotify-dev \
+        onedrive \
+        python3-dev \
+        python3-pip \
         && \
     $GIT_CLONE https://github.com/sstephenson/ruby-build.git \
                 /root/.rbenv/plugins/ruby-build && \

--- a/sntz/Dockerfile
+++ b/sntz/Dockerfile
@@ -38,7 +38,7 @@ RUN dpkg --configure -a && \
 
 ENV PATH /root/.rbenv/bin:$PATH
 
-RUN PIP_INSTALL="python -m pip --no-cache-dir install --upgrade" && \
+RUN PIP_INSTALL="python3 -m pip --no-cache-dir install --upgrade" && \
     echo 'eval "$(rbenv init -)"' >> /root/.bashrc && \
     /bin/bash -c "source /root/.bashrc" && \
     rbenv install 2.7.1 && rbenv global 2.7.1 && \


### PR DESCRIPTION
Resolves ticket STN-172: installing `onedrive` with proper version under sntz docker image. 
