### PR TITLE
Include dependencies for `nbconvert` [STN-184]

### DIFF
--- a/sntz/Dockerfile
+++ b/sntz/Dockerfile
@@ -33,6 +33,8 @@ RUN dpkg --configure -a && \
         python3-pip \
         software-properties-common \
         pandoc \
+        texlive-xetex \
+        texlive-plain-generic \
         && \
     $GIT_CLONE https://github.com/sstephenson/ruby-build.git \
                 /root/.rbenv/plugins/ruby-build && \
@@ -89,5 +91,6 @@ RUN PIP_INSTALL="python3 -m pip --no-cache-dir install --upgrade" && \
         openpyxl \
         nbdev \
         nbconvert \
+        traitlets \
         && \
     rm -rf /var/lib/apt/lists/* /tmp/* ~/*

--- a/sntz/Dockerfile
+++ b/sntz/Dockerfile
@@ -32,6 +32,7 @@ RUN dpkg --configure -a && \
         python3-dev \
         python3-pip \
         software-properties-common \
+        pandoc \
         && \
     $GIT_CLONE https://github.com/sstephenson/ruby-build.git \
                 /root/.rbenv/plugins/ruby-build && \
@@ -87,5 +88,6 @@ RUN PIP_INSTALL="python3 -m pip --no-cache-dir install --upgrade" && \
         checksumdir \
         openpyxl \
         nbdev \
+        nbconvert \
         && \
     rm -rf /var/lib/apt/lists/* /tmp/* ~/*


### PR DESCRIPTION
As we wish to include report exporting function basic dependencies of nbcovert should be allocated. 
